### PR TITLE
Improve address type naming

### DIFF
--- a/src/addr/host.rs
+++ b/src/addr/host.rs
@@ -1,0 +1,113 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::str::FromStr;
+
+use super::AddrParseError;
+use crate::addr::{Host, Localhost};
+
+/// An Internet host name which can be resolved by standard OS means (and thus
+/// accepted by `std::net` methods via use of [`ToSocketAddrs`] trait, when
+/// combined with a port address).
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display, From)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[display(inner)]
+#[cfg(feature = "dns")]
+pub enum InetHost {
+    /// IP name, including both IPv4 and IPv6 variants.
+    #[from]
+    #[from(Ipv4Addr)]
+    #[from(Ipv6Addr)]
+    Ip(IpAddr),
+
+    /// DNS-based name.
+    Dns(String),
+}
+
+#[cfg(feature = "dns")]
+impl Host for InetHost {}
+
+#[cfg(feature = "dns")]
+impl Localhost for InetHost {
+    fn localhost() -> Self {
+        Self::Ip(Localhost::localhost())
+    }
+}
+
+#[cfg(feature = "dns")]
+impl FromStr for InetHost {
+    type Err = AddrParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match IpAddr::from_str(s) {
+            Ok(addr) => Ok(Self::Ip(addr)),
+            // TODO: Check charset and format of a DNS name
+            Err(_) => Ok(Self::Dns(s.to_owned())),
+        }
+    }
+}
+
+/// A host name covers multiple types which are not necessarily resolved by an
+/// OS and may require additional name resolvers (like via SOCKS5 etc). The type
+/// doesn't provide an information about the resolver; for that use
+/// [`ProxiedHost`].
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Display, From)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[display(inner)]
+#[non_exhaustive]
+pub enum HostName {
+    #[from]
+    #[from(Ipv4Addr)]
+    #[from(Ipv6Addr)]
+    Ip(IpAddr),
+
+    #[cfg(feature = "dns")]
+    Dns(String),
+
+    #[cfg(feature = "tor")]
+    #[from]
+    Tor(super::tor::OnionAddrV3),
+
+    #[cfg(feature = "i2p")]
+    #[from]
+    I2p(super::i2p::I2pAddr),
+
+    #[cfg(feature = "nym")]
+    #[from]
+    Nym(super::nym::NymAddr),
+}
+
+impl Host for HostName {}
+
+#[cfg(feature = "dns")]
+impl From<InetHost> for HostName {
+    fn from(host: InetHost) -> Self {
+        match host {
+            InetHost::Ip(ip) => HostName::Ip(ip),
+            InetHost::Dns(dns) => HostName::Dns(dns),
+        }
+    }
+}
+
+impl FromStr for HostName {
+    type Err = AddrParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(addr) = IpAddr::from_str(s) {
+            return Ok(Self::Ip(addr));
+        }
+        #[cfg(feature = "tor")]
+        if s.ends_with(".onion") {
+            return super::tor::OnionAddrV3::from_str(s)
+                .map(Self::Tor)
+                .map_err(AddrParseError::from);
+        }
+        // TODO: Support Num and I2P
+        #[cfg(feature = "dns")]
+        {
+            Ok(Self::Dns(s.to_owned()))
+        }
+        #[cfg(not(feature = "dns"))]
+        {
+            Err(AddrParseError::UnknownAddressFormat)
+        }
+    }
+}

--- a/src/addr/mod.rs
+++ b/src/addr/mod.rs
@@ -1,21 +1,24 @@
 //! Cyphernet node address types
 
+mod host;
 #[cfg(feature = "i2p")]
 pub mod i2p;
-mod mix;
+mod net;
 #[cfg(feature = "nym")]
 pub mod nym;
 mod p2p;
-// mod proxied;
+mod proxied;
 #[cfg(feature = "tor")]
 pub mod tor;
 
+pub use host::HostName;
 #[cfg(feature = "dns")]
-pub use mix::HostName;
-pub use mix::{HostProxied, MixName, NetAddr, PartialAddr};
+pub use host::InetHost;
+pub use net::{NetAddr, PartialAddr};
 pub use p2p::{PeerAddr, PeerAddrParseError};
-// pub use proxied::ProxiedAddr;
+pub use proxied::{ProxiedAddr, ProxiedHost};
 
+/// Marker trait for all types of host names
 pub trait Host {}
 
 impl Host for std::net::IpAddr {}

--- a/src/addr/net.rs
+++ b/src/addr/net.rs
@@ -1,183 +1,9 @@
-use crate::addr::{Addr, Host, Localhost, ToSocketAddr};
 use std::fmt::Display;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs};
 use std::str::FromStr;
 use std::{fmt, io, vec};
 
-use super::AddrParseError;
-
-/// A host name which can be consumed by `std::net` methods via use of
-/// [`ToSocketAddrs`] trait (when combined with port address).
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display, From)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[display(inner)]
-#[cfg(feature = "dns")]
-pub enum HostName {
-    /// IP name, including both IPv4 and IPv6 variants
-    #[from]
-    #[from(Ipv4Addr)]
-    #[from(Ipv6Addr)]
-    Ip(IpAddr),
-
-    /// DNS-based name
-    Dns(String),
-}
-
-#[cfg(feature = "dns")]
-impl Host for HostName {}
-
-#[cfg(feature = "dns")]
-impl Localhost for HostName {
-    fn localhost() -> Self {
-        Self::Ip(Localhost::localhost())
-    }
-}
-
-#[cfg(feature = "dns")]
-impl FromStr for HostName {
-    type Err = AddrParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match IpAddr::from_str(s) {
-            Ok(addr) => Ok(Self::Ip(addr)),
-            // TODO: Check charset and format of a DNS name
-            Err(_) => Ok(Self::Dns(s.to_owned())),
-        }
-    }
-}
-
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Display, From)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[display(inner)]
-#[non_exhaustive]
-pub enum MixName {
-    #[from]
-    #[from(Ipv4Addr)]
-    #[from(Ipv6Addr)]
-    Ip(IpAddr),
-
-    #[cfg(feature = "dns")]
-    Dns(String),
-
-    #[cfg(feature = "tor")]
-    #[from]
-    Tor(super::tor::OnionAddrV3),
-
-    #[cfg(feature = "i2p")]
-    #[from]
-    I2p(super::i2p::I2pAddr),
-
-    #[cfg(feature = "nym")]
-    #[from]
-    Nym(super::nym::NymAddr),
-}
-
-impl Host for MixName {}
-
-#[cfg(feature = "dns")]
-impl From<HostName> for MixName {
-    fn from(host: HostName) -> Self {
-        match host {
-            HostName::Ip(ip) => MixName::Ip(ip),
-            HostName::Dns(dns) => MixName::Dns(dns),
-        }
-    }
-}
-
-impl FromStr for MixName {
-    type Err = AddrParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Ok(addr) = IpAddr::from_str(s) {
-            return Ok(Self::Ip(addr));
-        }
-        #[cfg(feature = "tor")]
-        if s.ends_with(".onion") {
-            return super::tor::OnionAddrV3::from_str(s)
-                .map(Self::Tor)
-                .map_err(AddrParseError::from);
-        }
-        // TODO: Support Num and I2P
-        #[cfg(feature = "dns")]
-        {
-            Ok(Self::Dns(s.to_owned()))
-        }
-        #[cfg(not(feature = "dns"))]
-        {
-            Err(AddrParseError::UnknownAddressFormat)
-        }
-    }
-}
-
-#[cfg(feature = "dns")]
-type DefaultAddr = NetAddr<HostName>;
-#[cfg(not(feature = "dns"))]
-type DefaultAddr = NetAddr<IpAddr>;
-
-#[derive(Clone, PartialEq, Eq, Hash, Debug, From)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[non_exhaustive]
-pub enum HostProxied<P: ToSocketAddrs + Addr = DefaultAddr> {
-    #[cfg(feature = "dns")]
-    #[from]
-    #[from(IpAddr)]
-    #[from(Ipv4Addr)]
-    #[from(Ipv6Addr)]
-    Native(HostName),
-
-    #[cfg(not(feature = "dns"))]
-    #[from(IpAddr)]
-    #[from(Ipv4Addr)]
-    #[from(Ipv6Addr)]
-    Native(IpAddr),
-
-    Ip(IpAddr, P),
-
-    #[cfg(feature = "dns")]
-    Dns(String, P),
-
-    #[cfg(feature = "tor")]
-    Tor(super::tor::OnionAddrV3, P),
-
-    #[cfg(feature = "i2p")]
-    I2p(super::i2p::I2pAddr, P),
-
-    #[cfg(feature = "nym")]
-    Nym(super::nym::NymAddr, P),
-}
-
-impl<P: ToSocketAddrs + Addr> Host for HostProxied<P> {}
-
-impl<P: ToSocketAddrs + Addr> HostProxied<P> {
-    pub fn with_proxy(host: MixName, proxy: P) -> Self {
-        match host {
-            MixName::Ip(ip) => HostProxied::Ip(ip, proxy),
-            #[cfg(feature = "dns")]
-            MixName::Dns(dns) => HostProxied::Dns(dns, proxy),
-            #[cfg(feature = "tor")]
-            MixName::Tor(tor) => HostProxied::Tor(tor, proxy),
-            #[cfg(feature = "i2p")]
-            MixName::I2p(i2p) => HostProxied::I2p(i2p, proxy),
-            #[cfg(feature = "nym")]
-            MixName::Nym(nym) => HostProxied::Nym(nym, proxy),
-        }
-    }
-
-    pub fn proxy(&self) -> Option<&P> {
-        match self {
-            HostProxied::Native(_) => None,
-            HostProxied::Ip(_, proxy) => Some(proxy),
-            #[cfg(feature = "dns")]
-            HostProxied::Dns(_, proxy) => Some(proxy),
-            #[cfg(feature = "tor")]
-            HostProxied::Tor(_, proxy) => Some(proxy),
-            #[cfg(feature = "i2p")]
-            HostProxied::I2p(_, proxy) => Some(proxy),
-            #[cfg(feature = "nym")]
-            HostProxied::Nym(_, proxy) => Some(proxy),
-        }
-    }
-}
+use crate::addr::{Addr, AddrParseError, Host, InetHost, Localhost, ToSocketAddr};
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -297,13 +123,13 @@ impl ToSocketAddrs for NetAddr<IpAddr> {
 }
 
 #[cfg(feature = "dns")]
-impl ToSocketAddrs for NetAddr<HostName> {
+impl ToSocketAddrs for NetAddr<InetHost> {
     type Iter = vec::IntoIter<SocketAddr>;
 
     fn to_socket_addrs(&self) -> io::Result<Self::Iter> {
         match &self.host {
-            HostName::Dns(dns) => (dns.as_str(), self.port).to_socket_addrs(),
-            HostName::Ip(ip) => Ok(SocketAddr::new(*ip, self.port)
+            InetHost::Dns(dns) => (dns.as_str(), self.port).to_socket_addrs(),
+            InetHost::Ip(ip) => Ok(SocketAddr::new(*ip, self.port)
                 .to_socket_addrs()?
                 .collect::<Vec<_>>()
                 .into_iter()),


### PR DESCRIPTION
* `InetHost` - IP addr or DNS name
* `HostName` - IP, DNS, Tor, I2P, Nym host name (no port or proxy information)
* `NetAddr` - any type of host name + port information
* `PartialAddr` - any type of host name + optional port, which defaults to generic const if not provided
* `PeerAddr` - any of the above addresses + node public key for authentication
* `ProxiedHost` - host name + proxy (there are IP/DNS w/o proxy and with proxy)
* `ProxiedAddr` - any of the above addresses + proxy (thus IP/DNS is always proxied)
