### PR TITLE
Add Sync requirement for EcPk

### DIFF
--- a/cyphergraphy/src/lib.rs
+++ b/cyphergraphy/src/lib.rs
@@ -114,7 +114,7 @@ pub enum EcVerifyError {
 /// # Safety
 ///
 /// The type provides no guarantees on the key validity upon deserialization.
-pub trait EcPk: Clone + Eq + Send + Debug + MultiDisplay<Encoding> {
+pub trait EcPk: Clone + Eq + Send + Sync + Debug + MultiDisplay<Encoding> {
     const COMPRESSED_LEN: usize;
     const CURVE_NAME: &'static str;
 


### PR DESCRIPTION
Required for eidolon::Error to be used in io::Error