### PR TITLE
addr: I2P Addresses

### DIFF
--- a/addr/Cargo.toml
+++ b/addr/Cargo.toml
@@ -21,8 +21,8 @@ serde = { version = "1", features = ["derive"], optional = true }
 
 [features]
 dns = []
-tor = ["sha3", "cyphergraphy/ed25519", "base32"]
-i2p = ["cyphergraphy/ed25519"]
+tor = ["base32", "cyphergraphy/ed25519", "sha3"]
+i2p = ["base32", "cyphergraphy/ed25519"]
 nym = []
 p2p-ed25519 = ["cyphergraphy/ed25519"]
 p2p-secp256k1 = ["cyphergraphy/secp256k1"]

--- a/addr/src/host.rs
+++ b/addr/src/host.rs
@@ -134,7 +134,14 @@ impl FromStr for HostName {
                 .map(Self::Tor)
                 .map_err(AddrParseError::from);
         }
-        // TODO: Support Num and I2P
+        #[cfg(feature = "i2p")]
+        if super::i2p::ends_with_suffix(s) {
+            return super::i2p::I2pAddr::from_str(s)
+                .map(Self::I2p)
+                .map_err(AddrParseError::from);
+        }
+
+        // TODO: Support Num
         #[cfg(feature = "dns")]
         {
             Ok(Self::Dns(s.to_owned()))

--- a/addr/src/i2p.rs
+++ b/addr/src/i2p.rs
@@ -22,16 +22,225 @@
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
-#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
+use base32;
+
+const SUFFIX_I2P: &str = ".i2p";
+const SUFFIX_I2P_ALT: &str = ".i2p.alt";
+
+/// Checks if the given string ends with a valid I2P address suffix,
+/// and thus could be considered for parsing as an I2P address.
+pub fn ends_with_suffix(s: &str) -> bool {
+    s.ends_with(SUFFIX_I2P) || s.ends_with(SUFFIX_I2P_ALT)
+}
+
+const SUFFIX_B32_I2P: &str = ".b32.i2p";
+const SUFFIX_B32_I2P_ALT: &str = ".b32.i2p.alt";
+
+const ALPHABET: base32::Alphabet = base32::Alphabet::RFC4648 { padding: false };
+
+const B32_LEN_BYTES: usize = 32;
+const B32_LEN_CHARS: usize = 52;
+
+const EXT_B32_CHECKSUM_BYTES: usize = 3;
+const EXT_B32_MIN_LEN_CHARS: usize = 56;
+
+/// An I2P address, with support for [Base32 Names] and the [.i2p.alt Domain].
+///
+/// The main purpose of this implementation is to reliably detect I2P addresses,
+/// and differentiate them from other types of addresses, such as Tor onion
+/// addresses or regular domain names. It is not inteded to be fully compliant
+/// with I2P. The following limitations are known:
+///
+///   1. Base64 names are not parsed/validated. In particular, this
+///      implementation does not check whether their length is within bounds
+///      (between 516 and 616 bytes).
+///   2. [Naming Rules] are not checked. In particular, this implementation
+///      does not exclude malformed names, such as those containing "..".
+///   3. Checksums of [Extended Base32 Names] are not checked.
+///
+/// If these limitations are addressed in the future, some invalid addresses
+/// might not be accepted in future versions.
+///
+/// [.i2p.alt Domain]: https://i2p.net/docs/overview/naming/#i2palt-domain
+/// [Base32 Names]: https://i2p.net/docs/overview/naming/#base32-names
+/// [Extended Base32 Names]: https://i2p.net/docs/overview/naming/#extended-base32-names
+/// [Naming Rules]: https://i2p.net/docs/overview/naming/#naming-rules
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct I2pAddr([u8; 32]);
+pub enum I2pAddr {
+    Base32 {
+        digest: [u8; B32_LEN_BYTES],
+        alt: bool,
+    },
+    ExtendedBase32 {
+        checksum: [u8; EXT_B32_CHECKSUM_BYTES],
+        payload: Vec<u8>,
+        alt: bool,
+    },
+    Name {
+        name: String,
+        alt: bool,
+    },
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Display, Error, From)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[display(doc_comments)]
+#[non_exhaustive]
+pub enum I2pAddrParseError {
+    /// I2P address {0} does not end with known I2P suffix.
+    NoSuffix(String),
+
+    /// I2P address {0} is not valid Base32.
+    InvalidBase32(String),
+
+    /// I2P address {0} has an invalid length.
+    InvalidLen(String),
+}
+
+impl I2pAddr {
+    fn try_from_b32(stripped: &str, alt: bool) -> Result<Self, I2pAddrParseError> {
+        if stripped.len() == B32_LEN_CHARS {
+            let Some(digest) = base32::decode(ALPHABET, stripped) else {
+                return Err(I2pAddrParseError::InvalidBase32(stripped.to_owned()));
+            };
+            if digest.len() != B32_LEN_BYTES {
+                return Err(I2pAddrParseError::InvalidLen(stripped.to_owned()));
+            }
+            match digest.try_into() {
+                Ok(digest) => Ok(Self::Base32 { digest, alt }),
+                Err(_) => unreachable!("digest length is checked"),
+            }
+        } else if stripped.len() >= EXT_B32_MIN_LEN_CHARS {
+            let Some(decoded) = base32::decode(ALPHABET, stripped) else {
+                return Err(I2pAddrParseError::InvalidBase32(stripped.to_owned()));
+            };
+            let (checksum, payload) = decoded.split_at(EXT_B32_CHECKSUM_BYTES);
+
+            // TODO: Check checksum.
+
+            Ok(Self::ExtendedBase32 {
+                checksum: checksum
+                    .try_into()
+                    .unwrap_or_else(|_| unreachable!("checksum length is guaranteed by split_at")),
+                payload: payload.to_vec(),
+                alt,
+            })
+        } else {
+            Err(I2pAddrParseError::InvalidLen(stripped.to_owned()))
+        }
+    }
+
+    fn prefix(&self) -> String {
+        match self {
+            Self::Base32 { digest, .. } => {
+                base32::encode(ALPHABET, digest.as_slice()).to_lowercase()
+            }
+            Self::ExtendedBase32 {
+                checksum, payload, ..
+            } => base32::encode(ALPHABET, &[checksum.as_slice(), payload.as_slice()].concat())
+                .to_lowercase(),
+            Self::Name { name, .. } => name.clone(),
+        }
+    }
+
+    fn suffix(&self) -> &'static str {
+        match self {
+            Self::Base32 { alt, .. } | Self::ExtendedBase32 { alt, .. } => {
+                if *alt {
+                    SUFFIX_B32_I2P_ALT
+                } else {
+                    SUFFIX_B32_I2P
+                }
+            }
+            Self::Name { alt, .. } => {
+                if *alt {
+                    SUFFIX_I2P_ALT
+                } else {
+                    SUFFIX_I2P
+                }
+            }
+        }
+    }
+}
 
 impl FromStr for I2pAddr {
-    type Err = ();
+    type Err = I2pAddrParseError;
 
-    fn from_str(_s: &str) -> Result<Self, Self::Err> { todo!() }
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(stripped) = s.strip_suffix(SUFFIX_B32_I2P) {
+            Self::try_from_b32(stripped, false)
+        } else if let Some(stripped) = s.strip_suffix(SUFFIX_B32_I2P_ALT) {
+            Self::try_from_b32(stripped, true)
+        } else if let Some(stripped) = s.strip_suffix(SUFFIX_I2P) {
+            Ok(Self::Name {
+                name: stripped.to_owned(),
+                alt: false,
+            })
+        } else if let Some(stripped) = s.strip_suffix(SUFFIX_I2P_ALT) {
+            Ok(Self::Name {
+                name: stripped.to_owned(),
+                alt: true,
+            })
+        } else {
+            Err(I2pAddrParseError::NoSuffix(s.to_owned()))
+        }
+    }
 }
 
 impl Display for I2pAddr {
-    fn fmt(&self, _f: &mut Formatter<'_>) -> fmt::Result { todo!() }
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}{}", self.prefix(), self.suffix())
+    }
+}
+
+impl From<I2pAddr> for String {
+    fn from(addr: I2pAddr) -> Self {
+        addr.to_string()
+    }
+}
+
+impl TryFrom<String> for I2pAddr {
+    type Error = I2pAddrParseError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::from_str(&s)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn roundrip() {
+        for raw in [
+            // https://pablo.rauzy.name/outreach/2600/how-to-run-an-i2p-hidden-service.txt
+            "khpazz3f747z5zet72s6g3dccw53bfdqyhxt5da4sv7ouve5veuq.b32.i2p",
+            // https://i2p.net/docs/overview/naming/
+            "udhdrtrcetjm5sxzskjyr5ztpeszydbh4dpl3pl4utgqqw2v4jna.b32.i2p",
+            "i2p-projekt.i2p",
+            // https://github.com/PurpleI2P/i2pd_docs_en/blob/838f712527ae0c58c03f419c1fa31f16d52152bb/docs/tutorials/Filesharing/qBittorrent.md?plain=1#L20
+            "shx5vqsw7usdaunyzr2qmes2fq37oumybpudrd4jjj4e4vk4uusa.b32.i2p",
+            // https://www.reddit.com/r/i2p/comments/njm1d6/comment/gzf05kx/
+            "lhxgk47niirkle3zb35fyq2iyzgvpmzydjqbirzcjng3lookrmmxalzz.b32.i2p",
+        ] {
+            assert_eq!(raw, I2pAddr::from_str(raw).unwrap().to_string());
+
+            let raw = raw.to_owned() + ".alt";
+            assert_eq!(raw, I2pAddr::from_str(&raw).unwrap().to_string());
+        }
+    }
+
+    #[test]
+    fn invalid() {
+        for raw in [
+            // No suffix.
+            "khpazz3f747z5zet72s6g3dccw53bfdqyhxt5da4sv7ouve5veuq",
+            // Invalid length.
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.b32.i2p",
+        ] {
+            assert!(I2pAddr::from_str(raw).is_err());
+        }
+    }
 }

--- a/addr/src/lib.rs
+++ b/addr/src/lib.rs
@@ -180,6 +180,12 @@ pub enum AddrParseError {
     Tor(tor::OnionAddrParseError),
 
     #[from]
+    #[cfg(feature = "i2p")]
+    #[display(inner)]
+    /// invalid I2P address
+    I2p(i2p::I2pAddrParseError),
+
+    #[from]
     #[display(inner)]
     /// invalid IP or socket address
     InvalidSocketAddr(std::net::AddrParseError),


### PR DESCRIPTION
I gave up on checksums for [Extended Base32 Names](https://i2p.net/en/docs/overview/naming/#extended-base32-names). Test vectors would be nice but I could not find any.

The proposed implementation is still quite helpful to distinguish I2P addresses from others.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added I2P address parsing support when the `i2p` feature is enabled, with support for multiple address formats (.b32.i2p, .i2p, .i2p.alt).
  * Improved error handling with dedicated error types for I2P address parsing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->