### PR TITLE
cyphernet: Bump cyphergraphy to 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 amplify = "4.6.0"
-cyphergraphy = { path = "cyphergraphy", version = "0.3.0" }
+cyphergraphy = { path = "cyphergraphy", version = "0.3.1" }
 cypheraddr = { path = "addr", version = "0.4.1" }
 eidolon-auth = { path = "eidolon", version = "0.3.0" }
 socks5-client = { path = "socks5-client", version = "0.4.2" }


### PR DESCRIPTION
It looks like the version of `cyphergraphy` was bumped in `/cyphergraphy/Cargo.toml` https://github.com/cyphernet-labs/cyphernet.rs/commit/23a1eb1b5d8522f2b03f017d40b080d13fba333a#diff-479357b402bf1f91dfab0b24b8aae0c58dca07aec619d6623c64456742adb614L3. Should the version in `/Cargo.toml` not match this?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency versions to improve stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->